### PR TITLE
Fix link to image for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can use this library to:
 
 Some examples are shown below:
 
-![movetk_algorithm_visualization](docs/images/algorithm_visualization.png)
+![movetk_algorithm_visualization](documentation/images/algorithm_visualization.png)
 
 The following table lists some of the algorithms available in MoveTK
 


### PR DESCRIPTION
The link seems to be the old one still, the images are now in the ``documentation/images`` folder